### PR TITLE
bionic: add electric fence into memory debug list, use code 15.

### DIFF
--- a/libc/bionic/malloc_debug_common.cpp
+++ b/libc/bionic/malloc_debug_common.cpp
@@ -387,6 +387,9 @@ static void malloc_init_impl() {
     case 10:
       so_name = "libc_malloc_debug_leak.so";
       break;
+    case 15:
+      so_name = "libefence.so";
+      break;
     case 20:
       // Quick check: debug level 20 can only be handled in emulator.
       if (!qemu_running) {
@@ -472,6 +475,9 @@ static void malloc_init_impl() {
       break;
     case 10:
       InitMalloc(malloc_impl_handle, &malloc_dispatch_table, "chk");
+      break;
+    case 15:
+      InitMalloc(malloc_impl_handle, &malloc_dispatch_table, "efence");
       break;
     case 20:
       InitMalloc(malloc_impl_handle, &malloc_dispatch_table, "qemu_instrumented");


### PR DESCRIPTION
To enable efence feature, just do "setprop libc.debug.malloc 15"

Change-Id: I1ae6ae05a60a6813426f5cf35be08238613b0965